### PR TITLE
add label and anniversary interfaces without dependency injection

### DIFF
--- a/api-server-wasm/src/application/usecases.rs
+++ b/api-server-wasm/src/application/usecases.rs
@@ -1,1 +1,3 @@
 pub mod wiki_usecases;
+pub mod label_usecases;
+pub mod anniversary_usecases;

--- a/api-server-wasm/src/application/usecases/anniversary_usecases.rs
+++ b/api-server-wasm/src/application/usecases/anniversary_usecases.rs
@@ -1,0 +1,30 @@
+use crate::domain::entities::setting::Anniversaries;
+use crate::domain::repositories::anniversary_repository::AnniversaryRepository;
+use worker::Result;
+
+
+pub struct AnniversaryUsecases<R: AnniversaryRepository> {
+    repository: R,
+}
+
+impl<R: AnniversaryRepository> AnniversaryUsecases<R> {
+    pub fn new(repository: R) -> Self {
+        Self { repository }
+    }
+
+    pub async fn get_anniversaries(&self) -> Result<Vec<Anniversaries>> {
+        self.repository.get_anniversaries().await
+    }
+
+    pub async fn create_anniversary(&self, anniversary: &Anniversaries) -> Result<()> {
+        self.repository.create_anniversary(anniversary).await
+    }
+
+    pub async fn update_anniversary(&self, anniversary: &mut Anniversaries) -> Result<()> {
+        self.repository.update_anniversary(anniversary).await
+    }
+
+    pub async fn delete_anniversary(&self, anniversary: &mut Anniversaries) -> Result<()> {
+        self.repository.delete_anniversary(anniversary).await
+    }
+}

--- a/api-server-wasm/src/application/usecases/label_usecases.rs
+++ b/api-server-wasm/src/application/usecases/label_usecases.rs
@@ -1,0 +1,30 @@
+use crate::domain::entities::setting::Labels;
+use crate::domain::repositories::label_repository::LabelRepository;
+use worker::Result;
+
+
+pub struct LabelUsecases<R: LabelRepository> {
+    repository: R,
+}
+
+impl<R: LabelRepository> LabelUsecases<R> {
+    pub fn new(repository: R) -> Self {
+        Self { repository }
+    }
+
+    pub async fn get_labels(&self) -> Result<Vec<Labels>> {
+        self.repository.get_labels().await
+    }
+
+    pub async fn create_label(&self, label: &Labels) -> Result<()> {
+        self.repository.create_label(label).await
+    }
+
+    pub async fn update_label(&self, label: &mut Labels) -> Result<()> {
+        self.repository.update_label(label).await
+    }
+
+    pub async fn delete_label(&self, label: &mut Labels) -> Result<()> {
+        self.repository.delete_label(label).await
+    }
+}

--- a/api-server-wasm/src/domain/repositories.rs
+++ b/api-server-wasm/src/domain/repositories.rs
@@ -1,1 +1,3 @@
 pub mod wiki_repository;
+pub mod label_repository;
+pub mod anniversary_repository;

--- a/api-server-wasm/src/domain/repositories/anniversary_repository.rs
+++ b/api-server-wasm/src/domain/repositories/anniversary_repository.rs
@@ -1,0 +1,11 @@
+use crate::domain::entities::setting::Anniversaries;
+use crate::async_trait::async_trait;
+use worker::Result;
+
+#[async_trait(?Send)]
+pub trait AnniversaryRepository {
+    async fn get_anniversaries(&self) -> Result<Vec<Anniversaries>>;
+    async fn create_anniversary(&self, anniversary: &Anniversaries) -> Result<()>;
+    async fn update_anniversary(&self, anniversary: &mut Anniversaries) -> Result<()>;
+    async fn delete_anniversary(&self, anniversary: &mut Anniversaries) -> Result<()>;
+}

--- a/api-server-wasm/src/domain/repositories/label_repository.rs
+++ b/api-server-wasm/src/domain/repositories/label_repository.rs
@@ -1,0 +1,11 @@
+use crate::domain::entities::setting::Labels;
+use crate::async_trait::async_trait;
+use worker::Result;
+
+#[async_trait(?Send)]
+pub trait LabelRepository {
+    async fn get_labels(&self) -> Result<Vec<Labels>>;
+    async fn create_label(&self, label: &Labels) -> Result<()>;
+    async fn update_label(&self, label: &mut Labels) -> Result<()>;
+    async fn delete_label(&self, label: &mut Labels) -> Result<()>;
+}

--- a/api-server-wasm/src/infrastructure/repositories.rs
+++ b/api-server-wasm/src/infrastructure/repositories.rs
@@ -1,1 +1,3 @@
 pub mod d1_wiki_repository;
+pub mod d1_label_repository;
+pub mod d1_anniversary_repository;

--- a/api-server-wasm/src/infrastructure/repositories/d1_anniversary_repository.rs
+++ b/api-server-wasm/src/infrastructure/repositories/d1_anniversary_repository.rs
@@ -1,0 +1,76 @@
+use crate::domain::entities::setting::Anniversaries;
+use crate::domain::entities::service::LatestVersion;
+use crate::domain::repositories::anniversary_repository::AnniversaryRepository;
+use crate::async_trait::async_trait;
+use worker::{D1Database, Result};
+use std::sync::Arc;
+
+pub struct D1AnniversaryRepository {
+    db: Arc<D1Database>,
+}
+
+impl D1AnniversaryRepository {
+    pub fn new(db: D1Database) -> Self {
+        Self { db: Arc::new(db) }
+    }
+}
+
+#[async_trait(?Send)]
+impl AnniversaryRepository for D1AnniversaryRepository {
+    async fn get_anniversaries(&self) -> Result<Vec<Anniversaries>> {
+        let query = self.db.prepare("select * from anniversaries order by id desc");
+        let result = query.all().await?;
+        result.results::<Anniversaries>()
+    }
+
+    async fn create_anniversary(&self, anniversary: &Anniversaries) -> Result<()> {
+        let statement = self.db.prepare("insert into anniversaries (month, date, description, version) values (?1, ?2, ?3, ?4)");
+        let query = statement.bind(&[anniversary.month.into(),
+                                                          anniversary.date.into(),
+                                                          anniversary.description.clone().into(),
+                                                          anniversary.version.into()])?;
+        query.run().await?;
+        Ok(())
+    }
+
+    async fn update_anniversary(&self, anniversary: &mut Anniversaries) -> Result<()> {
+        let fetch_version_statement = self.db.prepare("select version from anniversaries where id = ?1");
+        let fetch_version_query = fetch_version_statement.bind(&[anniversary.id.into()])?;
+        let fetch_version_result = fetch_version_query.first::<LatestVersion>(None).await?;
+        if let Some(latest) = fetch_version_result {
+            if anniversary.version == latest.version {
+                anniversary.version += 1;
+            } else {
+                return Err(worker::Error::RustError("Attempt to update a stale object".to_string()))
+            }
+        } else {
+            return Err(worker::Error::RustError("Version is found None".to_string()))
+        }
+        let statement = self.db.prepare("update anniversaries set month = ?1, date = ?2, description = ?3, version = ?4");
+        let query = statement.bind(&[anniversary.month.into(),
+                                                          anniversary.date.into(),
+                                                          anniversary.description.clone().into(),
+                                                          anniversary.version.into()])?;
+        query.run().await?;
+        Ok(())
+    }
+
+    async fn delete_anniversary(&self, anniversary: &mut Anniversaries) -> Result<()> {
+        let fetch_version_statement = self.db.prepare("select version from anniversaries where id = ?1");
+        let fetch_version_query = fetch_version_statement.bind(&[anniversary.id.into()])?;
+        let fetch_version_result = fetch_version_query.first::<LatestVersion>(None).await?;
+        if let Some(latest) = fetch_version_result {
+            if anniversary.version == latest.version {
+                anniversary.version += 1;
+            } else {
+                return Err(worker::Error::RustError("Attempt to update a stale object".to_string()))
+            }
+        } else {
+            return Err(worker::Error::RustError("Version is found None".to_string()))
+        }
+        let statement = self.db.prepare("delete from anniversaries where id = ?1");
+        let query = statement.bind(&[anniversary.id.into()])?;
+        query.run().await?;
+        Ok(())
+    }
+}

--- a/api-server-wasm/src/infrastructure/repositories/d1_label_repository.rs
+++ b/api-server-wasm/src/infrastructure/repositories/d1_label_repository.rs
@@ -1,0 +1,75 @@
+use crate::domain::entities::setting::Labels;
+use crate::domain::entities::service::LatestVersion;
+use crate::domain::repositories::label_repository::LabelRepository;
+use crate::async_trait::async_trait;
+use worker::{D1Database, Result};
+use std::sync::Arc;
+
+pub struct D1LabelRepository {
+    db: Arc<D1Database>,
+}
+
+impl D1LabelRepository {
+    pub fn new(db: D1Database) -> Self {
+        Self { db: Arc::new(db) }
+    }
+}
+
+#[async_trait(?Send)]
+impl LabelRepository for D1LabelRepository {
+    async fn get_labels(&self) -> Result<Vec<Labels>> {
+        let query = self.db.prepare("select * from labels order by id desc");
+        let result = query.all().await?;
+        result.results::<Labels>()
+    }
+
+    async fn create_label(&self, label: &Labels) -> Result<()> {
+        let statement = self.db.prepare("insert into labels (name, label, version) values (?1, ?2, ?3)");
+        let query = statement.bind(&[label.name.clone().into(),
+                                                          label.label.clone().into(),
+                                                          label.version.into()])?;
+        query.run().await?;
+        Ok(())
+    }
+
+    async fn update_label(&self, label: &mut Labels) -> Result<()> {
+        let fetch_version_statement = self.db.prepare("select version from labels where id = ?1");
+        let fetch_version_query = fetch_version_statement.bind(&[label.id.into()])?;
+        let fetch_version_result = fetch_version_query.first::<LatestVersion>(None).await?;
+        if let Some(latest) = fetch_version_result {
+            if label.version == latest.version {
+                label.version += 1;
+            } else {
+                return Err(worker::Error::RustError("Attempt to update a stale object".to_string()))
+            }
+        } else {
+            return Err(worker::Error::RustError("Version is found None".to_string()))
+        }
+        let statement = self.db.prepare("update labels set name = ?1, label = ?2, version where id = ?3");
+        let query = statement.bind(&[label.name.clone().into(),
+                                                          label.label.clone().into(),
+                                                          label.version.into(),
+                                                          label.id.into()])?;
+        query.run().await?;
+        Ok(())
+    }
+
+    async fn delete_label(&self, label: &mut Labels) -> Result<()> {
+        let fetch_version_statement = self.db.prepare("select version from labels where id = ?1");
+        let fetch_version_query = fetch_version_statement.bind(&[label.id.into()])?;
+        let fetch_version_result = fetch_version_query.first::<LatestVersion>(None).await?;
+        if let Some(latest) = fetch_version_result {
+            if label.version == latest.version {
+                label.version += 1;
+            } else {
+                return Err(worker::Error::RustError("Attempt to update a stale object".to_string()))
+            }
+        } else {
+            return Err(worker::Error::RustError("Version is found None".to_string()))
+        }
+        let statement = self.db.prepare("delete from labels where id = ?1");
+        let query = statement.bind(&[label.id.into()])?;
+        query.run().await?;
+        Ok(())
+    }
+}

--- a/api-server-wasm/src/interfaces/api.rs
+++ b/api-server-wasm/src/interfaces/api.rs
@@ -1,1 +1,3 @@
 pub mod wiki_controller;
+pub mod label_controller;
+pub mod anniversary_controller;

--- a/api-server-wasm/src/interfaces/api/anniversary_controller.rs
+++ b/api-server-wasm/src/interfaces/api/anniversary_controller.rs
@@ -1,0 +1,62 @@
+use crate::application::usecases::anniversary_usecases::AnniversaryUsecases;
+use crate::domain::entities::setting::Anniversaries;
+use crate::domain::repositories::anniversary_repository::AnniversaryRepository;
+use worker::{Request, Response, Result};
+use serde_json::from_str;
+
+pub struct AnniversaryController<R: AnniversaryRepository> {
+    usecases: AnniversaryUsecases<R>,
+}
+
+impl<R: AnniversaryRepository> AnniversaryController<R> {
+    pub fn new(usecases: AnniversaryUsecases<R>) -> Self {
+        Self { usecases }
+    }
+
+    pub async fn get_anniversaries(&self) -> Result<Response> {
+        let result = match self.usecases.get_anniversaries().await {
+            Ok(anniversarys) => anniversarys,
+            Err(e) => return Response::error(e.to_string(), 500)
+        };
+        return Response::from_json(&result)
+    }
+
+    pub async fn create_anniversary(&self, req: &mut Request) -> Result<Response> {
+        let json_body = match req.text().await {
+            Ok(body) => body,
+            Err(_) => return Response::error("Bad request", 400)
+        };
+        let anniversary: Anniversaries = match from_str(json_body.as_str()) {
+            Ok(anniversary) => anniversary,
+            Err(_) => return Response::error("Invalid request body", 400)
+        };
+        self.usecases.create_anniversary(&anniversary).await?;
+        return Response::ok("An anniversary was created")
+    }
+
+    pub async fn update_anniversary(&self, req: &mut Request) -> Result<Response> {
+        let json_body = match req.text().await {
+            Ok(body) => body,
+            Err(_) => return Response::error("Bad request", 400)
+        };
+        let mut anniversary: Anniversaries = match from_str(json_body.as_str()) {
+            Ok(anniversary) => anniversary,
+            Err(_) => return Response::error("Invalid request body", 400)
+        };
+        self.usecases.update_anniversary(&mut anniversary).await?;
+        return Response::ok("An anniversary was updated")
+    }
+
+    pub async fn delete_anniversary(&self, req: &mut Request) -> Result<Response> {
+        let json_body = match req.text().await {
+            Ok(body) => body,
+            Err(_) => return Response::error("Bad request", 400)
+        };
+        let mut anniversary: Anniversaries = match from_str(json_body.as_str()) {
+            Ok(anniversary) => anniversary,
+            Err(_) => return Response::error("Invalid request body", 400)
+        };
+        self.usecases.delete_anniversary(&mut anniversary).await?;
+        return Response::ok("An anniversary was updated")
+    }
+}

--- a/api-server-wasm/src/interfaces/api/label_controller.rs
+++ b/api-server-wasm/src/interfaces/api/label_controller.rs
@@ -1,0 +1,62 @@
+use crate::application::usecases::label_usecases::LabelUsecases;
+use crate::domain::entities::setting::Labels;
+use crate::domain::repositories::label_repository::LabelRepository;
+use worker::{Request, Response, Result};
+use serde_json::from_str;
+
+pub struct LabelController<R: LabelRepository> {
+    usecases: LabelUsecases<R>,
+}
+
+impl<R: LabelRepository> LabelController<R> {
+    pub fn new(usecases: LabelUsecases<R>) -> Self {
+        Self { usecases }
+    }
+
+    pub async fn get_labels(&self) -> Result<Response> {
+        let result = match self.usecases.get_labels().await {
+            Ok(labels) => labels,
+            Err(e) => return Response::error(e.to_string(), 500)
+        };
+        return Response::from_json(&result)
+    }
+
+    pub async fn create_label(&self, req: &mut Request) -> Result<Response> {
+        let json_body = match req.text().await {
+            Ok(body) => body,
+            Err(_) => return Response::error("Bad request", 400)
+        };
+        let label: Labels = match from_str(json_body.as_str()) {
+            Ok(label) => label,
+            Err(_) => return Response::error("Invalid request body", 400)
+        };
+        self.usecases.create_label(&label).await?;
+        return Response::ok("A label was created")
+    }
+
+    pub async fn update_label(&self, req: &mut Request) -> Result<Response> {
+        let json_body = match req.text().await {
+            Ok(body) => body,
+            Err(_) => return Response::error("Bad request", 400)
+        };
+        let mut label: Labels = match from_str(json_body.as_str()) {
+            Ok(label) => label,
+            Err(_) => return Response::error("Invalid request body", 400)
+        };
+        self.usecases.update_label(&mut label).await?;
+        return Response::ok("A label was updated")
+    }
+
+    pub async fn delete_label(&self, req: &mut Request) -> Result<Response> {
+        let json_body = match req.text().await {
+            Ok(body) => body,
+            Err(_) => return Response::error("Bad request", 400)
+        };
+        let mut label: Labels = match from_str(json_body.as_str()) {
+            Ok(label) => label,
+            Err(_) => return Response::error("Invalid request body", 400)
+        };
+        self.usecases.delete_label(&mut label).await?;
+        return Response::ok("A label was updated")
+    }
+}

--- a/api-server-wasm/src/lib.rs
+++ b/api-server-wasm/src/lib.rs
@@ -47,12 +47,13 @@ async fn main(req: Request, env: Env, _ctx: Context) -> Result<Response> {
 
     let db_str = get_db_env(&req)?;
     let db = env.d1(db_str.as_str())?;
+
     let wiki_repository = D1WikiRepository::new(db);
     let wiki_usecases = WikiUsecases::new(wiki_repository);
     let wiki_controller = WikiController::new(wiki_usecases);
 
     let app_state = AppState {
-        wiki_controller
+        wiki_controller,
     };
 
 


### PR DESCRIPTION
エントリーポイントファイルにdbインスタンスを複数おくと、所有権の問題が生じるため、そこは別で対策を考える